### PR TITLE
Docker build improvements

### DIFF
--- a/test_helpers.py
+++ b/test_helpers.py
@@ -252,16 +252,29 @@ class LocalRunner(ScriptRunner):
 class DockerBuilder:
     """Builds docker images"""
 
+    def print_build_logs(self, logs):
+        """Prints the build logs"""
+        for chunk in logs:
+            if stdout_chunk := chunk.get("stream"):
+                print(stdout_chunk, end="")
+
     def __init__(self, early_bird_locker: EarlyBirdLocker):
         self.docker_client = docker.from_env()
         self.early_bird_locker = early_bird_locker
 
     def build(self, build_context: str, image_name: str):
         """Builds the docker image, given the build context and image name"""
-        _, logs = self.docker_client.images.build(path=build_context, tag=image_name)
-        for chunk in logs:
-            if stdout_chunk := chunk.get("stream"):
-                print(stdout_chunk, end="")
+        print(f"Building docker image {image_name} from {build_context}\n")
+        logs = []
+        try:
+            _, logs = self.docker_client.images.build(path=build_context, tag=image_name)
+            print("Build succeeded:\n")
+            self.print_build_logs(logs)
+        except docker.errors.BuildError as e:
+            print("Build failed:\n")
+            print(e.msg)
+            self.print_build_logs(e.build_log)
+            raise(e)
 
     def docker_image(self, language_name: str) -> str:
         """Fixture that returns the image name to use for running the script under test, but first

--- a/test_helpers.py
+++ b/test_helpers.py
@@ -258,7 +258,11 @@ class DockerBuilder:
 
     def build(self, build_context: str, image_name: str):
         """Builds the docker image, given the build context and image name"""
-        _, logs = self.docker_client.images.build(path=build_context, tag=image_name)
+        _, logs = self.docker_client.images.build(
+            path=build_context,
+            tag=image_name,
+            rm=True,
+        )
         for chunk in logs:
             if stdout_chunk := chunk.get("stream"):
                 print(stdout_chunk, end="")


### PR DESCRIPTION
# 1. Always print errors that happen when building.

Example:

Build script that fails:
![CleanShot 2024-07-02 at 12 42 31@2x](https://github.com/enkb123/rosetta-io/assets/9061/af0f6b66-ab7c-47b1-880c-5dfe230faa5e)

Message:
![CleanShot 2024-07-02 at 12 42 05@2x](https://github.com/enkb123/rosetta-io/assets/9061/a18edd6a-6c1d-4b7f-9eea-6a1189d1c6da)


# 2. Automatically remove containers created during the build process

This should keep help keep storage from running out as quickly. @enkb123 you will probably want to run `docker container prune` after this is merged.