### PR TITLE
Add TEST_LOCAL env var support

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ def test_encode(self, script):
     assert script.output == 'SGVsbG8sIHdvcmxkIQ==\n'
 ```
 
+Alternatively, you can set the `TEST_LOCAL` environment variable to `true` or `1` to run all tests locally without having to mark them with `@pytest.mark.local`.
+
+E.g. run all Swift tests locally:
+
+```bash
+TEST_LOCAL=1 pytest -k swift
+```
+
 
 [env-vars-docker]: https://docs.docker.com/engine/reference/commandline/cli/#environment-variables
 [env-vars-pytest-xdist]: https://pytest-xdist.readthedocs.io/en/stable/distribution.html

--- a/test_suite.py
+++ b/test_suite.py
@@ -1,6 +1,7 @@
 # pylint: disable=redefined-outer-name, missing-class-docstring
 
 import json
+import os
 from re import sub
 
 import pytest
@@ -83,7 +84,7 @@ class Bash3(Language):
 class Bash5(Bash3):
     name = 'bash5'
 
-    
+
 class Lua(Language):
     name = 'lua'
     interpreter = 'lua'
@@ -114,6 +115,8 @@ def language(request: pytest.FixtureRequest):
 @pytest.fixture
 def is_local(request: pytest.FixtureRequest):
     """Fixture that returns True if the test is marked as local, False otherwise"""
+    if os.environ.get("TEST_LOCAL", "false").lower() in ("true", "1", "yes"):
+        return True
     markers_names = map(lambda m: m.name, request.node.iter_markers())
     return "local" in markers_names
 


### PR DESCRIPTION
This PR adds support for a TEST_LOCAL env var, which marks all tests as local without having to put `@pytest.mark.local` in the code everywhere.

@enkb123 if you merge this PR and merge it into your `swift` branch, you'll be able to use it to run the tests faster. Your mac should already have Swift installed.

You'll be able to do this: `TEST_LOCAL=1 pytest -k swift`, which should be quite fast.

The C# scripts/setup won't be able to work this way, but Go will if you can set up Go on your machine (I'll look into how to do that)